### PR TITLE
Pin router to 6.0.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ copr-key
 .DS_Store
 .fake
 *.log
+*.tgz

--- a/iml-socket-worker.spec
+++ b/iml-socket-worker.spec
@@ -3,7 +3,7 @@
 Name:       iml-%{base_name}
 Version:    4.0.2
 # Release Start
-Release:    1%{?dist}
+Release:    2%{?dist}
 # Release End
 Summary:    Socket.io client that runs in a WebWorker.
 License:    MIT

--- a/package-lock.json
+++ b/package-lock.json
@@ -2677,7 +2677,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true,
           "optional": true
         }
@@ -5703,7 +5703,7 @@
         "kind-of": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@iml/fp": "^8.0.3",
     "@iml/math": "^6.0.1",
     "@iml/number-formatters": "1.0.1",
-    "@iml/router": "^6.0.2",
+    "@iml/router": "6.0.2",
     "highland": "3.0.0-beta.6",
     "socket.io-client": "2.1.1",
     "@iml/flow-highland": "^4.3.0",


### PR DESCRIPTION
Due to https://github.com/whamcloud/router/issues/14

We need to use an older version of iml-router.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>